### PR TITLE
Add the circular profile picture feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Possible options that can be passed to FortySecondsCV are:
 * `leftrightmargin=<length>` sets the left and right page margin for both 
   columns as well as how much space will be between both columns.
 * `profilepicsize=<length>` sets the width of the profile picture.
+* `profilepicstyle=profilecircle` clips the profile picture to a circle as in the original `twentysecondcv` class. 
 
 Note: 
 
@@ -306,16 +307,6 @@ has to be defined within the `document` environment.
 * Coloring
   `cvsection`, `cvsubsection` and description text colors can be defined as
   described in [class options](#class-options).
-
-* Profile picture styles
-  ```latex
-  \profileroundedcorners
-  ```
-  * is the one visible in the example below
-  ```latex
-  \profilecircle
-  ```
-  * clips the picture to a circle as in the original `twentysecondcv` class
 
 * Name and jobtitle combination with proper spacing, font and color
   ```late

--- a/fortysecondscv.cls
+++ b/fortysecondscv.cls
@@ -78,6 +78,9 @@
 \newlength\profilepicsize%
 \setlength{\profilepicsize}{0.7\sidebarwidth}
 \DeclareOptionX{profilepicsize}{\setlength{\profilepicsize}{#1}}
+\newcommand*{\profilepicstyle}{}
+\DeclareOptionX{profilepicstyle}{\renewcommand{\profilepicstyle}{#1}}
+
 
 % show sidebar and page margins
 \newtoggle{tshowframes}
@@ -239,6 +242,10 @@
 \newcommand{\plotprofilepicture}{}
 \newcommand*{\cvprofilepic}[1]{
 	\renewcommand{\cvprofilepic}{#1}
+}
+\ifthenelse{\equal{\profilepicstyle}{profilecircle}}{
+	\renewcommand{\plotprofilepicture}{\profilecircle}
+}{
 	\renewcommand{\plotprofilepicture}{\profileroundedcorners}
 }
 
@@ -300,6 +307,22 @@
 				(0, 1) [rounded corners=0.15\sidebartextwidth] -- 
 				(1, 1) [sharp corners] --
 				(1, 0) [rounded corners=0.15\sidebartextwidth] -- cycle;
+			\end{scope}
+		\end{tikzpicture}
+	\end{figure}
+}
+
+\newcommand{\profilecircle}{%
+	\begin{figure}\centering
+		\begin{tikzpicture}[x=\profilepicsize, y=\profilepicsize]
+			\begin{scope}
+				\clip (0, 0) circle (0.5);
+				\node[anchor=center, inner sep=0pt, outer sep=0pt] (profilepic) at (0,0) {
+				\includegraphics[width=\profilepicsize]{\cvprofilepic}};
+			\end{scope}
+			\begin{scope}
+			\draw	[line width=0.02\sidebartextwidth, color=iconcolor]
+				(0, 0) circle (0.5\profilepicsize);
 			\end{scope}
 		\end{tikzpicture}
 	\end{figure}

--- a/template.tex
+++ b/template.tex
@@ -24,7 +24,8 @@
 %   sidebarwidth=0.4\paperwidth,
 %   topbottommargin=0.03\paperheight,
 %   leftrightmargin=20pt,
-%   proilepicsize=4.5cm,
+%   profilepicsize=4.5cm,
+%   profilepicstyle=profilecircle,
 ]{fortysecondscv}
 
 % improve word spacing and hyphenation


### PR DESCRIPTION
Add the circular profile picture feature.
- Added option `profilepicstyle` which can be set to `profilecircle` to generate a circular profile picture.
  - The default remains the `\profileroundedcorners` macro.
- Added `profilepicstyle` option to the template file.
  - Also fixed a typo in the `profilepicsize` option.
- Documented the new `profilepicstyle` option.
- Closes #3.