### PR TITLE
Added zoom and shifting as profile pic options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,13 @@ Possible options that can be passed to FortySecondsCV are:
 * `leftrightmargin=<length>` sets the left and right page margin for both 
   columns as well as how much space will be between both columns.
 * `profilepicsize=<length>` sets the width of the profile picture.
-* `profilepicstyle=profilecircle` clips the profile picture to a circle as in the original `twentysecondcv` class. 
+* `profilepicstyle=profilecircle` clips the profile picture to a circle as in
+  the original `twentysecondcv` class.
+* `profilepiczoom=<float>` sets the zoom factor for the profile picture.
+  Together with the two options below, this allows you to use your favorite
+  profile picture directly without modification and crop it here.
+* `profilepicxshift=<length>` sets the xshift for the profile picture.
+* `profilepicyshift=<length>` sets the yshift for the profile picture.
 
 Note: 
 

--- a/fortysecondscv.cls
+++ b/fortysecondscv.cls
@@ -82,6 +82,12 @@
 \DeclareOptionX{profilepicstyle}{\renewcommand{\profilepicstyle}{#1}}
 \newcommand*{\profilepiczoom}{}
 \DeclareOptionX{profilepiczoom}{\renewcommand{\profilepiczoom}{#1}}
+\newlength\profilepicxshift
+\setlength{\profilepicxshift}{0mm}
+\DeclareOptionX{profilepicxshift}{\setlength{\profilepicxshift}{#1}}
+\newlength\profilepicyshift
+\setlength{\profilepicyshift}{0mm}
+\DeclareOptionX{profilepicyshift}{\setlength{\profilepicyshift}{#1}}
 
 
 
@@ -301,7 +307,7 @@
 				(0, 1) [rounded corners=0.15\sidebartextwidth] -- 
 				(1, 1) [sharp corners] --
 				(1, 0) [rounded corners=0.15\sidebartextwidth] -- cycle;
-			\node[anchor=south west, inner sep=0pt] (profilepic) at (0, 0)
+			\node[anchor=south west, inner sep=0pt, xshift=\profilepicxshift, yshift=\profilepicyshift] (profilepic) at (0, 0)
 				{\includegraphics[width=\profilepiczoom\profilepicsize]{\cvprofilepic}};
 			\end{scope}
 			\begin{scope}
@@ -320,7 +326,7 @@
 		\begin{tikzpicture}[x=\profilepicsize, y=\profilepicsize]
 			\begin{scope}
 				\clip (0, 0) circle (0.5);
-				\node[anchor=center, inner sep=0pt, outer sep=0pt] (profilepic) at (0,0) {
+				\node[anchor=center, inner sep=0pt, outer sep=0pt, xshift=\profilepicxshift, yshift=\profilepicyshift] (profilepic) at (0,0) {
 				\includegraphics[width=\profilepiczoom\profilepicsize]{\cvprofilepic}};
 			\end{scope}
 			\begin{scope}

--- a/fortysecondscv.cls
+++ b/fortysecondscv.cls
@@ -307,8 +307,10 @@
 				(0, 1) [rounded corners=0.15\sidebartextwidth] -- 
 				(1, 1) [sharp corners] --
 				(1, 0) [rounded corners=0.15\sidebartextwidth] -- cycle;
-			\node[anchor=south west, inner sep=0pt, xshift=\profilepicxshift, yshift=\profilepicyshift] (profilepic) at (0, 0)
-				{\includegraphics[width=\profilepiczoom\profilepicsize]{\cvprofilepic}};
+			\node[anchor=center, inner sep=0pt, xshift=\profilepicxshift,
+					yshift=\profilepicyshift] (profilepic) at (0.5, 0.5)
+				{\includegraphics[width=\profilepiczoom\profilepicsize]
+					{\cvprofilepic}};
 			\end{scope}
 			\begin{scope}
 			\draw	[line width=0.02\sidebartextwidth, color=iconcolor]
@@ -326,8 +328,11 @@
 		\begin{tikzpicture}[x=\profilepicsize, y=\profilepicsize]
 			\begin{scope}
 				\clip (0, 0) circle (0.5);
-				\node[anchor=center, inner sep=0pt, outer sep=0pt, xshift=\profilepicxshift, yshift=\profilepicyshift] (profilepic) at (0,0) {
-				\includegraphics[width=\profilepiczoom\profilepicsize]{\cvprofilepic}};
+				\node[anchor=center, inner sep=0pt, outer sep=0pt,
+						xshift=\profilepicxshift, yshift=\profilepicyshift]
+					(profilepic) at (0,0) {
+				\includegraphics[width=\profilepiczoom\profilepicsize]
+					{\cvprofilepic}};
 			\end{scope}
 			\begin{scope}
 			\draw	[line width=0.02\sidebartextwidth, color=iconcolor]

--- a/fortysecondscv.cls
+++ b/fortysecondscv.cls
@@ -80,6 +80,9 @@
 \DeclareOptionX{profilepicsize}{\setlength{\profilepicsize}{#1}}
 \newcommand*{\profilepicstyle}{}
 \DeclareOptionX{profilepicstyle}{\renewcommand{\profilepicstyle}{#1}}
+\newcommand*{\profilepiczoom}{}
+\DeclareOptionX{profilepiczoom}{\renewcommand{\profilepiczoom}{#1}}
+
 
 
 % show sidebar and page margins
@@ -299,7 +302,7 @@
 				(1, 1) [sharp corners] --
 				(1, 0) [rounded corners=0.15\sidebartextwidth] -- cycle;
 			\node[anchor=south west, inner sep=0pt] (profilepic) at (0, 0)
-				{\includegraphics[width=\profilepicsize]{\cvprofilepic}};
+				{\includegraphics[width=\profilepiczoom\profilepicsize]{\cvprofilepic}};
 			\end{scope}
 			\begin{scope}
 			\draw	[line width=0.02\sidebartextwidth, color=iconcolor]
@@ -318,7 +321,7 @@
 			\begin{scope}
 				\clip (0, 0) circle (0.5);
 				\node[anchor=center, inner sep=0pt, outer sep=0pt] (profilepic) at (0,0) {
-				\includegraphics[width=\profilepicsize]{\cvprofilepic}};
+				\includegraphics[width=\profilepiczoom\profilepicsize]{\cvprofilepic}};
 			\end{scope}
 			\begin{scope}
 			\draw	[line width=0.02\sidebartextwidth, color=iconcolor]

--- a/template.tex
+++ b/template.tex
@@ -27,6 +27,8 @@
 %   profilepicsize=4.5cm,
 %   profilepicstyle=profilecircle,
 %   profilepiczoom=1.0,
+%   profilepicxshift=0mm,
+%   profilepicyshift=0mm,
 ]{fortysecondscv}
 
 % improve word spacing and hyphenation

--- a/template.tex
+++ b/template.tex
@@ -26,6 +26,7 @@
 %   leftrightmargin=20pt,
 %   profilepicsize=4.5cm,
 %   profilepicstyle=profilecircle,
+%   profilepiczoom=1.0,
 ]{fortysecondscv}
 
 % improve word spacing and hyphenation


### PR DESCRIPTION
Added zoom and shifting as profile pic options.
- Added 'profilepiczoom' option, that allows you to zoom the chosen profile picture.
- Added options 'profilepicxshift' and 'profilepicyshift' to allow shifting the profile picture inside the selected picture frame.
- Documented the 'profilepiczoom', 'profilepicxshift' and 'profilepicyshift' options.

Closes #6.