### PR TITLE
Add feature to set profile picture border width.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Possible options that can be passed to FortySecondsCV are:
 * `leftrightmargin=<length>` sets the left and right page margin for both 
   columns as well as how much space will be between both columns.
 * `profilepicsize=<length>` sets the width of the profile picture.
+* `profilepicborderwidth=<length>` sets the width of the profile picture's
+  border.
 * `profilepicstyle=profilecircle` clips the profile picture to a circle as in
   the original `twentysecondcv` class.
 * `profilepiczoom=<float>` sets the zoom factor for the profile picture.

--- a/fortysecondscv.cls
+++ b/fortysecondscv.cls
@@ -78,6 +78,9 @@
 \newlength\profilepicsize%
 \setlength{\profilepicsize}{0.7\sidebarwidth}
 \DeclareOptionX{profilepicsize}{\setlength{\profilepicsize}{#1}}
+\newlength\profilepicborderwidth%
+\setlength{\profilepicborderwidth}{3.5pt}
+\DeclareOptionX{profilepicborderwidth}{\setlength{\profilepicborderwidth}{#1}}
 \newcommand*{\profilepicstyle}{}
 \DeclareOptionX{profilepicstyle}{\renewcommand{\profilepicstyle}{#1}}
 \newcommand*{\profilepiczoom}{}
@@ -302,23 +305,25 @@
 		% §12 (scopes), §13.2 (coordinate systems)
 		\begin{tikzpicture}[x=\profilepicsize, y=\profilepicsize]
 			\begin{scope}
-			\path[clip]
-				(0, 0) [sharp corners] --
-				(0, 1) [rounded corners=0.15\sidebartextwidth] --
-				(1, 1) [sharp corners] --
-				(1, 0) [rounded corners=0.15\sidebartextwidth] -- cycle;
-			\node[anchor=center, inner sep=0pt, xshift=\profilepicxshift,
-					yshift=\profilepicyshift] (profilepic) at (0.5, 0.5)
-				{\includegraphics[width=\profilepiczoom\profilepicsize]
-					{\cvprofilepic}};
+				\path[clip]
+					(0, 0) [sharp corners] --
+					(0, 1) [rounded corners=0.15\sidebartextwidth] --
+					(1, 1) [sharp corners] --
+					(1, 0) [rounded corners=0.15\sidebartextwidth] -- cycle;
+				\node[anchor=center, inner sep=0pt, xshift=\profilepicxshift,
+						yshift=\profilepicyshift] (profilepic) at (0.5, 0.5)
+					{\includegraphics[width=\profilepiczoom\profilepicsize]
+						{\cvprofilepic}};
 			\end{scope}
-			\begin{scope}
-			\draw	[line width=0.02\sidebartextwidth, color=iconcolor]
-				(0, 0) [sharp corners] --
-				(0, 1) [rounded corners=0.15\sidebartextwidth] --
-				(1, 1) [sharp corners] --
-				(1, 0) [rounded corners=0.15\sidebartextwidth] -- cycle;
-			\end{scope}
+			\ifdim \profilepicborderwidth > 0pt
+				\begin{scope}
+					\draw	[line width=\profilepicborderwidth, color=iconcolor]
+					(0, 0) [sharp corners] --
+					(0, 1) [rounded corners=0.15\sidebartextwidth] --
+					(1, 1) [sharp corners] --
+					(1, 0) [rounded corners=0.15\sidebartextwidth] -- cycle;
+				\end{scope}
+			\fi
 		\end{tikzpicture}
 	\end{figure}
 }
@@ -334,10 +339,12 @@
 				\includegraphics[width=\profilepiczoom\profilepicsize]
 					{\cvprofilepic}};
 			\end{scope}
-			\begin{scope}
-			\draw	[line width=0.02\sidebartextwidth, color=iconcolor]
-				(0, 0) circle (0.5\profilepicsize);
-			\end{scope}
+			\ifdim \profilepicborderwidth > 0pt
+				\begin{scope}
+					\draw	[line width=\profilepicborderwidth, color=iconcolor]
+						(0, 0) circle (0.5\profilepicsize);
+				\end{scope}
+			\fi
 		\end{tikzpicture}
 	\end{figure}
 }

--- a/template.tex
+++ b/template.tex
@@ -25,6 +25,7 @@
 %	topbottommargin=0.03\paperheight,
 %	leftrightmargin=20pt,
 %	profilepicsize=4.5cm,
+%	profilepicborderwidth=3.5pt,
 %	profilepicstyle=profilecircle,
 %	profilepiczoom=1.0,
 %	profilepicxshift=0mm,


### PR DESCRIPTION
Added feature to set profile picture border width.
- Added support for `profilepicborderwidth` option, and fixed some indentation.
  - When `profilepicborderwidth` is set to 0, remove the border completely. TikZ will always draw a fine line otherwise, even when the width is set to 0pt.
- Documented `profilepicborderwidth` option and added it to template.tex.

Closes #10.