### PR TITLE
Fix regression of optional profile picture

### DIFF
--- a/fortysecondscv.cls
+++ b/fortysecondscv.cls
@@ -258,15 +258,15 @@
 \newcommand*{\cvjobtitle}[1]{\renewcommand{\cvjobtitle}{#1}}
 
 % profile picture (optional)
-% TODO let user choose style via class settings
 \newcommand{\plotprofilepicture}{}
 \newcommand*{\cvprofilepic}[1]{
 	\renewcommand{\cvprofilepic}{#1}
-}
-\ifthenelse{\equal{\profilepicstyle}{profilecircle}}{
-	\renewcommand{\plotprofilepicture}{\profilecircle}
-}{
-	\renewcommand{\plotprofilepicture}{\profileroundedcorners}
+
+	\ifthenelse{\equal{\profilepicstyle}{profilecircle}}{
+		\renewcommand{\plotprofilepicture}{\profilecircle}
+	}{
+		\renewcommand{\plotprofilepicture}{\profileroundedcorners}
+	}
 }
 
 % social network item; \social{<icon>}{<url>}{<text>}


### PR DESCRIPTION
Hi,

last year the profile picture was made optional.
It looks like there was an regression in #4. 
Currently leaving out the \cvprofilepic command leads to a compilation error.

This change fixes the regression and makes the profile picture optional again.