### PR TITLE
Reduce barskill height

### DIFF
--- a/fortysecondscv.cls
+++ b/fortysecondscv.cls
@@ -466,10 +466,10 @@
 
 \newcommand{\barskill}[3]{
 	% remove 1pt in width to prevent overfull box warnings
-	\begin{tikzpicture}[x=\sidebartextwidth-1pt, y=2ex]
-			\draw[fill, skillbg, rounded corners=0.5em]
+	\begin{tikzpicture}[x=\sidebartextwidth-1pt, y=1ex]
+			\draw[fill, skillbg, rounded corners=0.25em]
 				(0, 0) rectangle (1, 1);
-			\draw[fill, iconcolor!70, rounded corners=0.5em]
+			\draw[fill, iconcolor!70, rounded corners=0.25em]
 				(0, 0) rectangle (#3/100, 1);
 			\node[above right] at (0, 1) {\cvicon{#1} ~ \sidetext{#2}};
 	\end{tikzpicture}


### PR DESCRIPTION
Hi! Here is just a small proposal, which I think would make a better looking. It's okay if you find this unnecessary.

What I think is the width(or height) of the skill bar is too big, which looks bolder than the text above them. So I tried to decrease the size of them to half. Shown as below(ignore differences in fonts and other things). 

Thanks for taking the time to view this. 😃 


![image](https://user-images.githubusercontent.com/58005137/98485822-1a757780-21e7-11eb-8dfe-c8d66ee05aeb.png)
