### PR TITLE
Add cvjobtitle argument

### DIFF
--- a/fortysecondscv.cls
+++ b/fortysecondscv.cls
@@ -354,7 +354,7 @@
 \newcommand{\nameandjob}{%
 	{\Huge\color{maincolor}\cvname}\par%
 	\setlength{\parskip}{2ex}
-	{\Large\color{black!80}\cvjobtitle}\par%
+	{\Large\color{black!80}\cvjobtitle{}}\par%
 	\setlength{\parskip}{1ex}
 }
 


### PR DESCRIPTION
I got this error : 
```
Argument of \cvjobtitle has an extra }.
<inserted text> 
\par 
\makefrontsidebar
```
Adding {} to \cvjobtitle fixed it, although I am not 100% sure this is right.