### PR TITLE
Feat: Add cvlinkedin and cvgithub

### DIFF
--- a/fortysecondscv.cls
+++ b/fortysecondscv.cls
@@ -355,6 +355,8 @@
 \newcommand*{\cvkey}[2]{\cvcustomdata{\faKey}{%
 	\href{https://keyserver.ubuntu.com/pks/lookup?search=#2\&op=vindex\&fingerprint=on}{#1}%
 }}
+\newcommand*{\cvgithub}[1]{\cvcustomdata{\faGithub}{\href{https://github.com/#1}{#1}}}
+\newcommand*{\cvlinkedin}[2]{\cvcustomdata{\faLinkedin}{\href{https://www.linkedin.com/in/#1}{#2}}}
 
 % TODO find a cleaner solution for consistent spacing
 \newcommand{\nameandjob}{%


### PR DESCRIPTION
Personal information convenience commands for **linkedin** and **github**.

This might be helpful since many use these platforms in their cv.
For Github the name is also added to the create the hyperlink.
For Linkedin the first parameter is used for the hyperlink and the second for text that is displayed.

Do you like the idea? If yes, then is the code or okay or you want any changes? 
Once you are satisfied, I can update the readme and template accordingly.