### PR TITLE
Name and job (\cvnameandjob) position and format

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Possible options that can be passed to FortySecondsCV are:
   columns.
 * `leftrightmargin=<length>` sets the left and right page margin for both
   columns as well as how much space will be between both columns.
+* `nameandjobposition` controls the position of the name and job title with
+  regards the profile picture: 'after' (default), 'before' or hidden for any
+  other value.
 * `profilepicsize=<length>` sets the width of the profile picture.
 * `profilepicborderwidth=<length>` sets the width of the profile picture's
   border.

--- a/fortysecondscv.cls
+++ b/fortysecondscv.cls
@@ -135,6 +135,10 @@
 	\AtBeginDocument{\apptocmd{\personaldata}{\hline}{}{}}
 }
 
+% name and job position: 'after' (default) picture, 'before', or hidden (any other value)
+\newcommand*{\nameandjobposition}{after}
+\DeclareOptionX{nameandjobposition}{\renewcommand{\nameandjobposition}{#1}}
+
 % draw vertical guideline
 \newcommand{\plotvline}{}
 \DeclareOptionX{vline}{%
@@ -368,6 +372,19 @@
 	\setlength{\parskip}{2ex}
 	{\cvjobtitleformat\cvjobtitle}\par%
 	\setlength{\parskip}{1ex}
+}
+
+\newcommand{\nameandjobbeforepic}{%
+	\ifthenelse{\equal{\nameandjobposition}{before}}{%
+		\nameandjob
+		\vspace{1ex}
+	}{}
+}
+\newcommand{\nameandjobafterpic}{%
+	\ifthenelse{\equal{\nameandjobposition}{after}}{%
+		\vspace{1ex}
+		\nameandjob
+	}{}
 }
 
 \newcommand{\profileroundedcorners}{%
@@ -668,6 +685,9 @@
 		% most sidebar commands end with \par; increase space between them
 		\setlength{\parskip}{1ex}
 
+		% name and job - when \nameandjobposition = 'before'
+		\nameandjobbeforepic
+
 		% optionally insert logo picture before profile
 		\plotlogobefore
 
@@ -677,10 +697,8 @@
 		% optionally insert logo picture after profile
 		\plotlogoafter
 
-		\vspace{1ex}
-
-		% name and job
-		\nameandjob
+		% name and job - when \nameandjobposition = 'after'
+		\nameandjobafterpic
 
 		% personal information
 		\vspace*{0.5em}

--- a/fortysecondscv.cls
+++ b/fortysecondscv.cls
@@ -288,6 +288,12 @@
 % text in user-specific color
 \newcommand{\sidetext}[1]{\textcolor{sidetextcolor}{#1}}
 
+% style for name
+\newcommand*{\cvnameformat}{\Huge\color{maincolor}}
+
+% style for job title
+\newcommand*{\cvjobtitleformat}{\Large\color{black!80}}
+
 % mandatory personal information
 \newcommand*{\cvname}[1]{\renewcommand{\cvname}{#1}}
 \newcommand*{\cvjobtitle}[1]{\renewcommand{\cvjobtitle}{#1}}
@@ -358,9 +364,9 @@
 
 % TODO find a cleaner solution for consistent spacing
 \newcommand{\nameandjob}{%
-	{\Huge\color{maincolor}\cvname}\par%
+	{\cvnameformat\cvname}\par%
 	\setlength{\parskip}{2ex}
-	{\Large\color{black!80}\cvjobtitle}\par%
+	{\cvjobtitleformat\cvjobtitle}\par%
 	\setlength{\parskip}{1ex}
 }
 


### PR DESCRIPTION
Two changes related to `\cvnameandjob`:
* allow putting the name and job title above the profile picture (default remains below the picture)
* allow customizing the fonts used for the name and for the job title (use `\renewcommand*{\cvnameformat}{...}` for the name, `cvjobtitleformat` for the job title)